### PR TITLE
Update default parameters: RPS to 0.9 and model to gpt-4.1-mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,10 @@ After installing the extension, click on the extension icon to configure:
 
 - **API Endpoint**: The LLM API endpoint (default: `https://api.openai.com/v1/chat/completions`)
 - **API Key**: Your API key for authentication
-- **Model**: The model to use (default: `gpt-4.1-nano`)
+- **Model**: The model to use (default: `gpt-4.1-mini`)
 - **Target Language**: The language to translate to (default: `Japanese`)
+- **API Rate Limit**: Requests per second limit (default: `0.9 RPS`)
+- **Batch Size**: Maximum characters per batch request (default: `2000`)
 
 ## Usage
 
@@ -124,6 +126,8 @@ The extension consists of several key components:
 - **Progress Indication**: Shows translation progress with badge and notifications
 - **Error Handling**: Displays clear error messages when translation fails
 - **State Preservation**: Original content stored in `data-*` attributes
+- **Batch Translation**: Groups multiple elements into single API requests for efficiency
+- **Rate Limiting**: Configurable requests per second to respect API limits
 
 ## Development Guidelines
 
@@ -149,7 +153,9 @@ npm run build     # Ensure build succeeds
 ├── api.ts                  # LLM API wrapper
 ├── cache.ts                # LRU cache implementation
 ├── utils.ts                # Utility functions
-└── element-translator.ts   # Element-based translation logic
+├── element-translator.ts   # Element-based translation logic
+├── batch-translator.ts     # Batch translation coordinator
+└── rate-limiter.ts         # API rate limiting implementation
 
 /test
 ├── *.test.ts               # Test files for each module

--- a/src/api.ts
+++ b/src/api.ts
@@ -23,7 +23,7 @@ let rateLimiter: RateLimiter | null = null
 
 export function configureApi(config: ApiConfig): void {
   if (!rateLimiter || config.rps !== undefined) {
-    rateLimiter = new RateLimiter(config.rps || 0.5)
+    rateLimiter = new RateLimiter(config.rps || 0.9)
   }
 }
 
@@ -63,7 +63,7 @@ Only return the translated text without any explanation.`
   
   try {
     if (!rateLimiter) {
-      rateLimiter = new RateLimiter(0.5)
+      rateLimiter = new RateLimiter(0.9)
     }
     
     const response = await rateLimiter.execute(() => fetch(apiEndpoint, {

--- a/src/content.ts
+++ b/src/content.ts
@@ -168,7 +168,7 @@ async function translatePage() {
     const settings: TranslationSettings = {
       apiEndpoint: storageData.apiEndpoint || 'https://api.openai.com/v1/chat/completions',
       apiKey: storageData.apiKey,
-      model: storageData.model || 'gpt-4.1-nano',
+      model: storageData.model || 'gpt-4.1-mini',
       targetLanguage: storageData.targetLanguage || 'Japanese',
       viewportTranslation: storageData.viewportTranslation,
       batchSize: storageData.batchSize || 2000

--- a/src/popup.html
+++ b/src/popup.html
@@ -25,7 +25,7 @@
       
       <div class="form-group">
         <label for="model">Model:</label>
-        <input type="text" id="model" placeholder="gpt-4.1-nano" value="gpt-4.1-nano">
+        <input type="text" id="model" placeholder="gpt-4.1-mini" value="gpt-4.1-mini">
       </div>
       
       <div class="form-group">
@@ -37,7 +37,7 @@
         <label for="api-rps">API Rate Limit (requests per second):</label>
         <input type="number" id="api-rps" min="0.1" max="10" step="0.1" value="0.5">
         <small style="display: block; margin-top: 4px; color: #666;">
-          Limit the number of API requests per second (default: 0.5)
+          Limit the number of API requests per second (default: 0.9)
         </small>
       </div>
       

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -40,7 +40,7 @@ async function loadSettings() {
   if (settings.apiRps !== undefined) {
     apiRpsInput.value = settings.apiRps.toString()
   } else {
-    apiRpsInput.value = '0.5' // Default to 0.5 RPS
+    apiRpsInput.value = '0.9' // Default to 0.9 RPS
   }
   if (settings.batchSize !== undefined) {
     batchSizeInput.value = settings.batchSize.toString()
@@ -59,9 +59,9 @@ async function saveSettings() {
   const settings = {
     apiEndpoint: apiEndpointInput.value || 'https://api.openai.com/v1/chat/completions',
     apiKey: apiKeyInput.value,
-    model: modelInput.value || 'gpt-4.1-nano',
+    model: modelInput.value || 'gpt-4.1-mini',
     targetLanguage: targetLanguageInput.value || 'Japanese',
-    apiRps: parseFloat(apiRpsInput.value) || 0.5,
+    apiRps: parseFloat(apiRpsInput.value) || 0.9,
     batchSize: parseInt(batchSizeInput.value) || 2000,
     viewportTranslation: viewportTranslationCheckbox.checked
   }

--- a/test/popup.test.ts
+++ b/test/popup.test.ts
@@ -20,7 +20,7 @@ const mockElements = {
   apiKey: { value: '', addEventListener: vi.fn() } as any,
   model: { value: '', addEventListener: vi.fn() } as any,
   targetLanguage: { value: 'Japanese', addEventListener: vi.fn() } as any,
-  apiRps: { value: '0.5', addEventListener: vi.fn() } as any,
+  apiRps: { value: '0.9', addEventListener: vi.fn() } as any,
   batchSize: { value: '2000', addEventListener: vi.fn() } as any,
   viewportTranslation: { checked: true, addEventListener: vi.fn() } as any,
   saveSettings: { addEventListener: vi.fn() } as any,
@@ -55,7 +55,7 @@ describe('Popup', () => {
     mockElements.apiKey.value = ''
     mockElements.model.value = ''
     mockElements.targetLanguage.value = 'ja'
-    mockElements.apiRps.value = '0.5'
+    mockElements.apiRps.value = '0.9'
     mockElements.batchSize.value = '2000'
     mockElements.viewportTranslation.checked = true
     mockElements.status.textContent = ''
@@ -133,7 +133,7 @@ describe('Popup', () => {
         apiKey: 'new-key',
         model: 'gpt-4',
         targetLanguage: 'Japanese',
-        apiRps: 0.5,
+        apiRps: 0.9,
         batchSize: 2000,
         viewportTranslation: true
       })
@@ -157,9 +157,9 @@ describe('Popup', () => {
       expect(chrome.storage.local.set).toHaveBeenCalledWith({
         apiEndpoint: 'https://api.openai.com/v1/chat/completions',
         apiKey: 'some-key',
-        model: 'gpt-4.1-nano',
+        model: 'gpt-4.1-mini',
         targetLanguage: 'ja',
-        apiRps: 0.5,
+        apiRps: 0.9,
         batchSize: 2000,
         viewportTranslation: true
       })


### PR DESCRIPTION
## Summary
Update default configuration parameters for better performance and compatibility.

## Changes
- **API Rate Limit**: Increased from 0.5 to 0.9 requests per second
  - Provides ~80% faster translation speed while remaining conservative
- **Default Model**: Changed from `gpt-4.1-nano` to `gpt-4.1-mini`
  - Better model availability and performance

## Test Plan
- [x] All unit tests pass with new defaults
- [x] Popup UI shows correct default values
- [x] Extension builds successfully

🤖 Generated with [Claude Code](https://claude.ai/code)