### PR TITLE
Fix namu.wiki content translation issue

### DIFF
--- a/src/element-translator.ts
+++ b/src/element-translator.ts
@@ -73,7 +73,16 @@ export function getTranslatableElements(root: Element = document.body): Element[
   const selectors = [
     'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
     'li', 'td', 'th', 'blockquote', 'figcaption',
-    'dd', 'dt', '.text', '.content', '[class*="text"]'
+    'dd', 'dt', '.text', '.content', '[class*="text"]',
+    'div[class*="content"]', 'div[class*="article"]', 'div[class*="wiki"]',
+    'div[class*="body"]', 'div[class*="main"]', 'div[class*="paragraph"]',
+    'span[class*="text"]', 'span[class*="content"]',
+    // Common wiki/documentation selectors
+    '.wiki-paragraph', '.wiki-heading', '.wiki-content',
+    '.document-content', '.article-body', '.entry-content',
+    // Namu wiki specific
+    '[class*="wiki-paragraph"]', '[class*="wiki-heading"]',
+    '[class*="w-"]', '.wiki-table-wrapper td', '.wiki-table-wrapper th'
   ]
   
   const candidates = root.querySelectorAll(selectors.join(','))
@@ -89,15 +98,28 @@ export function getTranslatableElements(root: Element = document.body): Element[
       return
     }
     
-    // Skip if contains nested block elements (process leaves instead)
+    // Skip if contains many nested block elements (likely a container)
+    // But allow elements with a few nested elements (like div with spans)
     const blockElements = element.querySelectorAll('p, div, section, article, h1, h2, h3, h4, h5, h6')
-    if (blockElements.length > 0) {
+    if (blockElements.length > 3) {
+      return
+    }
+    
+    // Skip if the element is too large (likely a container)
+    const elementText = element.textContent?.trim() || ''
+    if (elementText.length > 5000) {
       return
     }
     
     // Check if has meaningful text content
     const text = element.textContent?.trim()
-    if (!text || text.length < 10) {
+    if (!text || text.length < 5) {
+      return
+    }
+    
+    // Skip if text is mostly numbers or special characters
+    const letterCount = (text.match(/[\p{L}]/gu) || []).length
+    if (letterCount < text.length * 0.3) {
       return
     }
     

--- a/test/element-translator.test.ts
+++ b/test/element-translator.test.ts
@@ -60,7 +60,7 @@ describe('Element Translator', () => {
 
     it('should skip elements with short text', () => {
       document.body.innerHTML = `
-        <p>Short</p>
+        <p>Hi</p>
         <p>This is a longer paragraph with enough content</p>
       `
 


### PR DESCRIPTION
## Summary
Fix the issue where main content on namu.wiki was not being translated while headers and menus were translated correctly.

## Problem
The element selection logic was too restrictive and missed content that:
- Was contained in `div` elements with content-related classes
- Had nested elements (common in wiki content)
- Had shorter text segments

## Solution
1. **Expanded selectors**: Added comprehensive selectors for:
   - `div` elements with content/article/wiki/body/main/paragraph classes
   - `span` elements with text/content classes
   - Wiki-specific selectors (wiki-paragraph, wiki-heading, etc.)
   - Namu wiki specific patterns (`[class*="w-"]`, wiki-table-wrapper)

2. **Relaxed filtering criteria**:
   - Allow elements with up to 3 nested block elements (was 0)
   - Reduce minimum text length from 10 to 5 characters
   - Add maximum element size (5000 chars) to avoid huge containers

3. **Added text quality check**:
   - Skip elements where less than 30% of characters are letters
   - Prevents translation of numeric data or special character sequences

## Testing
- [x] All unit tests pass
- [x] Updated test case for new 5-character minimum
- [ ] Manual testing on namu.wiki required

## Example sites that should now work better:
- https://namu.wiki/w/쥐아리
- Other wiki-style sites with similar structures

🤖 Generated with [Claude Code](https://claude.ai/code)