### PR TITLE
Fix GPT-5 model compatibility with max_completion_tokens

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -93,7 +93,10 @@ Only return the translated text.`
           { role: 'user', content: text }
         ],
         temperature: 0.3,
-        max_tokens: 4000
+        // Use max_completion_tokens for newer models, max_tokens for legacy
+        ...(model.toLowerCase().includes('gpt-5') 
+          ? { max_completion_tokens: 4000 }
+          : { max_tokens: 4000 })
       })
     }))
     

--- a/test/api.gpt5.test.ts
+++ b/test/api.gpt5.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { translateText } from '../src/api'
+
+// Mock fetch
+global.fetch = vi.fn()
+
+// Mock RateLimiter
+vi.mock('../src/rate-limiter', () => ({
+  RateLimiter: vi.fn().mockImplementation(() => ({
+    execute: vi.fn((fn) => fn()),
+    updateRPS: vi.fn()
+  }))
+}))
+
+describe('API - GPT-5 Compatibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should use max_completion_tokens for GPT-5 models', async () => {
+    const mockResponse = {
+      choices: [{
+        message: { content: 'Translated text' }
+      }]
+    }
+
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse
+    } as Response)
+
+    await translateText({
+      text: 'Test text',
+      targetLanguage: 'ja',
+      apiEndpoint: 'https://api.openai.com/v1/chat/completions',
+      apiKey: 'test-key',
+      model: 'gpt-5-nano'
+    })
+
+    const fetchCall = vi.mocked(global.fetch).mock.calls[0]
+    const body = JSON.parse(fetchCall[1]?.body as string)
+
+    expect(body.model).toBe('gpt-5-nano')
+    expect(body.max_completion_tokens).toBe(4000)
+    expect(body.max_tokens).toBeUndefined()
+  })
+
+  it('should use max_tokens for GPT-4 models', async () => {
+    const mockResponse = {
+      choices: [{
+        message: { content: 'Translated text' }
+      }]
+    }
+
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse
+    } as Response)
+
+    await translateText({
+      text: 'Test text',
+      targetLanguage: 'ja',
+      apiEndpoint: 'https://api.openai.com/v1/chat/completions',
+      apiKey: 'test-key',
+      model: 'gpt-4'
+    })
+
+    const fetchCall = vi.mocked(global.fetch).mock.calls[0]
+    const body = JSON.parse(fetchCall[1]?.body as string)
+
+    expect(body.model).toBe('gpt-4')
+    expect(body.max_tokens).toBe(4000)
+    expect(body.max_completion_tokens).toBeUndefined()
+  })
+
+  it('should handle GPT-5-turbo model variant', async () => {
+    const mockResponse = {
+      choices: [{
+        message: { content: 'Translated text' }
+      }]
+    }
+
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse
+    } as Response)
+
+    await translateText({
+      text: 'Test text',
+      targetLanguage: 'ja',
+      apiEndpoint: 'https://api.openai.com/v1/chat/completions',
+      apiKey: 'test-key',
+      model: 'GPT-5-Turbo'  // Test case insensitive
+    })
+
+    const fetchCall = vi.mocked(global.fetch).mock.calls[0]
+    const body = JSON.parse(fetchCall[1]?.body as string)
+
+    expect(body.model).toBe('GPT-5-Turbo')
+    expect(body.max_completion_tokens).toBe(4000)
+    expect(body.max_tokens).toBeUndefined()
+  })
+})

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -129,7 +129,7 @@ describe('API', () => {
       expect(body.model).toBe('gpt-4')
       expect(body.messages[1].content).toBe('Text with <strong_0>placeholder</strong_0>')
       expect(body.temperature).toBe(0.3)
-      expect(body.max_tokens).toBe(4000)
+      expect(body.max_tokens).toBe(4000) // GPT-4 uses max_tokens
     })
 
     it('should handle custom API endpoints', async () => {


### PR DESCRIPTION
## Summary
Fixes compatibility issue with GPT-5 models (like GPT-5-nano) that require `max_completion_tokens` parameter instead of `max_tokens`.

## Problem
When using GPT-5-nano or other GPT-5 models, the API returns an error:
```json
{
  "error": {
    "message": "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
    "type": "invalid_request_error",
    "param": "max_tokens",
    "code": "unsupported_parameter"
  }
}
```

## Solution
- Added conditional logic in `api.ts` to detect GPT-5 models
- Uses `max_completion_tokens` for GPT-5 models
- Maintains backward compatibility with `max_tokens` for GPT-4 and older models
- Model detection is case-insensitive

## Testing
- Added new test file `api.gpt5.test.ts` with comprehensive tests
- Tests verify correct parameter usage for both GPT-5 and GPT-4 models
- All existing tests continue to pass

## Changes
- Modified `src/api.ts` to add model-specific parameter handling
- Added `test/api.gpt5.test.ts` with GPT-5 specific tests
- Updated existing test to clarify GPT-4 behavior

🤖 Generated with [Claude Code](https://claude.ai/code)