### PR TITLE
Fix GPT-5 temperature parameter compatibility

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -92,7 +92,10 @@ Only return the translated text.`
           { role: 'system', content: systemPrompt },
           { role: 'user', content: text }
         ],
-        temperature: 0.3,
+        // GPT-5 models only support default temperature (1)
+        ...(model.toLowerCase().includes('gpt-5') 
+          ? {} // Omit temperature for GPT-5 to use default
+          : { temperature: 0.3 }),
         // Use max_completion_tokens for newer models, max_tokens for legacy
         ...(model.toLowerCase().includes('gpt-5') 
           ? { max_completion_tokens: 4000 }

--- a/test/api.gpt5.test.ts
+++ b/test/api.gpt5.test.ts
@@ -47,6 +47,7 @@ describe('API - GPT-5 Compatibility', () => {
     expect(body.model).toBe('gpt-5-nano')
     expect(body.max_completion_tokens).toBe(4000)
     expect(body.max_tokens).toBeUndefined()
+    expect(body.temperature).toBeUndefined() // GPT-5 doesn't support custom temperature
   })
 
   it('should use max_tokens for GPT-4 models', async () => {
@@ -75,6 +76,7 @@ describe('API - GPT-5 Compatibility', () => {
     expect(body.model).toBe('gpt-4')
     expect(body.max_tokens).toBe(4000)
     expect(body.max_completion_tokens).toBeUndefined()
+    expect(body.temperature).toBe(0.3) // GPT-4 supports custom temperature
   })
 
   it('should handle GPT-5-turbo model variant', async () => {
@@ -103,5 +105,6 @@ describe('API - GPT-5 Compatibility', () => {
     expect(body.model).toBe('GPT-5-Turbo')
     expect(body.max_completion_tokens).toBe(4000)
     expect(body.max_tokens).toBeUndefined()
+    expect(body.temperature).toBeUndefined() // GPT-5 doesn't support custom temperature
   })
 })


### PR DESCRIPTION
## Summary
Fixes temperature parameter compatibility issue with GPT-5 models that only support default temperature value.

## Problem
When using GPT-5-nano or other GPT-5 models, the API returns an error:
```json
{
  "error": {
    "message": "Unsupported value: 'temperature' does not support 0.3 with this model. Only the default (1) value is supported.",
    "type": "invalid_request_error",
    "param": "temperature",
    "code": "unsupported_value"
  }
}
```

## Solution
- Modified `api.ts` to omit temperature parameter for GPT-5 models (uses default value of 1)
- Maintains temperature 0.3 for GPT-4 and older models for better translation consistency
- Model detection is case-insensitive

## Implementation Details
The fix uses conditional spread operators to build the request body:
- For GPT-5 models: Omits temperature parameter entirely (API uses default of 1)
- For GPT-4 and older: Includes `temperature: 0.3` for more consistent translations

## Testing
- Updated existing GPT-5 tests to verify temperature is omitted
- Verified GPT-4 tests still include temperature parameter
- All tests passing ✅

## Changes
- Modified `src/api.ts` to conditionally include temperature parameter
- Updated `test/api.gpt5.test.ts` to verify correct temperature handling

## Related Issues
This is a follow-up to #24 which fixed the `max_completion_tokens` parameter issue.

🤖 Generated with [Claude Code](https://claude.ai/code)