### PR TITLE
Add dynamic context menu title based on target language

### DIFF
--- a/test/background.storage.test.ts
+++ b/test/background.storage.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock configureApi before importing background
+vi.mock('../src/api', () => ({
+  configureApi: vi.fn(),
+}))
+
+// Mock chrome API
+global.chrome = {
+  runtime: {
+    onInstalled: {
+      addListener: vi.fn(),
+    },
+    onMessage: {
+      addListener: vi.fn(),
+    },
+  },
+  contextMenus: {
+    create: vi.fn(),
+    update: vi.fn(),
+    onClicked: {
+      addListener: vi.fn(),
+    },
+  },
+  tabs: {
+    sendMessage: vi.fn(),
+  },
+  action: {
+    setBadgeText: vi.fn(),
+    setBadgeBackgroundColor: vi.fn(),
+    setIcon: vi.fn(),
+  },
+  storage: {
+    local: {
+      get: vi.fn().mockResolvedValue({}),
+      set: vi.fn().mockResolvedValue(undefined),
+    },
+    onChanged: {
+      addListener: vi.fn(),
+    },
+  },
+} as any
+
+describe('Background Script - Storage Changes', () => {
+  let storageChangeListener: any
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    
+    // Setup listener mocks
+    vi.mocked(chrome.storage.onChanged.addListener).mockImplementation((listener) => {
+      storageChangeListener = listener
+    })
+  })
+
+  it('should update context menu when target language changes', async () => {
+    // Mock initial storage
+    vi.mocked(chrome.storage.local.get).mockResolvedValue({ 
+      targetLanguage: 'ja',
+      apiRps: 0.5 
+    })
+    
+    await import('../src/background')
+    
+    // Simulate language change to Korean
+    vi.mocked(chrome.storage.local.get).mockResolvedValue({ 
+      targetLanguage: 'ko'
+    })
+    
+    const changes = {
+      targetLanguage: {
+        oldValue: 'ja',
+        newValue: 'ko'
+      }
+    }
+    
+    storageChangeListener(changes, 'local')
+    
+    // Wait for async update
+    await new Promise(resolve => setTimeout(resolve, 0))
+    
+    expect(chrome.contextMenus.update).toHaveBeenCalledWith('translate-page', {
+      title: 'AI Translation: Korean'
+    })
+  })
+
+  it('should update API config when RPS changes', async () => {
+    const { configureApi } = await import('../src/api')
+    
+    await import('../src/background')
+    
+    const changes = {
+      apiRps: {
+        oldValue: 0.5,
+        newValue: 1.0
+      }
+    }
+    
+    storageChangeListener(changes, 'local')
+    
+    expect(configureApi).toHaveBeenCalledWith({ rps: 1.0 })
+  })
+
+  it('should handle both language and RPS changes', async () => {
+    const { configureApi } = await import('../src/api')
+    
+    vi.mocked(chrome.storage.local.get).mockResolvedValue({ 
+      targetLanguage: 'en'
+    })
+    
+    await import('../src/background')
+    
+    const changes = {
+      targetLanguage: {
+        oldValue: 'ja',
+        newValue: 'en'
+      },
+      apiRps: {
+        oldValue: 0.5,
+        newValue: 0.9
+      }
+    }
+    
+    storageChangeListener(changes, 'local')
+    
+    // Wait for async update
+    await new Promise(resolve => setTimeout(resolve, 0))
+    
+    expect(chrome.contextMenus.update).toHaveBeenCalledWith('translate-page', {
+      title: 'AI Translation: English'
+    })
+    expect(configureApi).toHaveBeenCalledWith({ rps: 0.9 })
+  })
+
+  it('should ignore storage changes from sync area', async () => {
+    await import('../src/background')
+    
+    const changes = {
+      targetLanguage: {
+        oldValue: 'ja',
+        newValue: 'en'
+      }
+    }
+    
+    storageChangeListener(changes, 'sync')
+    
+    expect(chrome.contextMenus.update).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
Updates the right-click context menu to display "AI Translation: [Language]" instead of "Translate this page", dynamically showing the current target language.

## Changes

### Context Menu Enhancement
- **Before**: "Translate this page" (static text)
- **After**: "AI Translation: Japanese" (dynamic based on settings)

### Implementation Details
1. **Language Display Names**: Added mapping for common languages
   - ja → Japanese
   - en → English
   - ko → Korean
   - zh → Chinese
   - es → Spanish
   - fr → French
   - de → German
   - And more...

2. **Dynamic Updates**: Context menu title updates automatically when:
   - Extension is installed (reads from storage)
   - User changes target language in popup settings
   - Falls back to language code if not in predefined list

3. **Storage Integration**: 
   - Reads `targetLanguage` from chrome.storage.local
   - Listens for storage changes to update menu in real-time

## Benefits
- ✅ Users can see which language the page will be translated to before clicking
- ✅ Better clarity for users who frequently switch between target languages
- ✅ Consistent with the extension's dynamic configuration approach

## Test Results
- ✅ All tests passing (94 passed, 2 skipped)
- ✅ ESLint checks pass
- ✅ TypeScript compilation successful
- ✅ Build successful
- ✅ Added new test file for storage change handling

## Screenshots
The context menu will now show:
- "AI Translation: Japanese" when target is set to Japanese
- "AI Translation: Korean" when target is set to Korean
- "AI Translation: custom-lang" for custom language codes

🤖 Generated with [Claude Code](https://claude.ai/code)