### PR TITLE
feat: Update defaults and simplify translation mode

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -25,7 +25,7 @@
       
       <div class="form-group">
         <label for="model">Model:</label>
-        <input type="text" id="model" placeholder="gpt-4.1-mini" value="gpt-4.1-mini">
+        <input type="text" id="model" placeholder="gpt-4.1-nano" value="gpt-4.1-nano">
       </div>
       
       <div class="form-group">
@@ -43,21 +43,12 @@
       
       <div class="form-group">
         <label for="batch-size">Batch Size (characters per request):</label>
-        <input type="number" id="batch-size" min="500" max="8000" step="100" value="4000">
+        <input type="number" id="batch-size" min="500" max="8000" step="100" value="1000">
         <small style="display: block; margin-top: 4px; color: #666;">
-          Maximum characters to send in a single request (default: 4000)
+          Maximum characters to send in a single request (default: 1000)
         </small>
       </div>
       
-      <div class="form-group">
-        <label>
-          <input type="checkbox" id="viewport-translation" checked>
-          Smart Translation (translate as you scroll)
-        </label>
-        <small style="display: block; margin-top: 4px; color: #666;">
-          Automatically translates content as it becomes visible. Recommended for large pages.
-        </small>
-      </div>
       
       <button id="save-settings">Save Settings</button>
     </div>

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -7,7 +7,6 @@ const modelInput = document.getElementById('model') as HTMLInputElement
 const targetLanguageInput = document.getElementById('target-language') as HTMLInputElement
 const apiRpsInput = document.getElementById('api-rps') as HTMLInputElement
 const batchSizeInput = document.getElementById('batch-size') as HTMLInputElement
-const viewportTranslationCheckbox = document.getElementById('viewport-translation') as HTMLInputElement
 const saveSettingsButton = document.getElementById('save-settings') as HTMLButtonElement
 const translateButton = document.getElementById('translate-page') as HTMLButtonElement
 const restoreButton = document.getElementById('restore-page') as HTMLButtonElement
@@ -21,8 +20,7 @@ async function loadSettings() {
     'model',
     'targetLanguage',
     'apiRps',
-    'batchSize',
-    'viewportTranslation'
+    'batchSize'
   ])
   
   if (settings.apiEndpoint) {
@@ -45,12 +43,7 @@ async function loadSettings() {
   if (settings.batchSize !== undefined) {
     batchSizeInput.value = settings.batchSize.toString()
   } else {
-    batchSizeInput.value = '2000' // Default to 2000 characters
-  }
-  if (settings.viewportTranslation !== undefined) {
-    viewportTranslationCheckbox.checked = settings.viewportTranslation
-  } else {
-    viewportTranslationCheckbox.checked = true // Default to true
+    batchSizeInput.value = '1000' // Default to 1000 characters
   }
 }
 
@@ -59,11 +52,10 @@ async function saveSettings() {
   const settings = {
     apiEndpoint: apiEndpointInput.value || 'https://api.openai.com/v1/chat/completions',
     apiKey: apiKeyInput.value,
-    model: modelInput.value || 'gpt-4.1-mini',
+    model: modelInput.value || 'gpt-4.1-nano',
     targetLanguage: targetLanguageInput.value || 'Japanese',
     apiRps: parseFloat(apiRpsInput.value) || 0.9,
-    batchSize: parseInt(batchSizeInput.value) || 2000,
-    viewportTranslation: viewportTranslationCheckbox.checked
+    batchSize: parseInt(batchSizeInput.value) || 1000
   }
   
   await chrome.storage.local.set(settings)

--- a/test/content-viewport.test.ts
+++ b/test/content-viewport.test.ts
@@ -175,8 +175,7 @@ describe('Content Script - Viewport Translation', () => {
         apiEndpoint: 'https://api.openai.com/v1/chat/completions',
         apiKey: 'test-key',
         model: 'gpt-3.5-turbo',
-        targetLanguage: 'ja',
-        viewportTranslation: true
+        targetLanguage: 'ja'
       })
       
       // Import content script and get the message listener
@@ -222,8 +221,7 @@ describe('Content Script - Viewport Translation', () => {
         apiEndpoint: 'https://api.openai.com/v1/chat/completions',
         apiKey: 'test-key',
         model: 'gpt-3.5-turbo',
-        targetLanguage: 'ja',
-        viewportTranslation: true
+        targetLanguage: 'ja'
       })
       
       // Reset modules to get fresh instance
@@ -279,8 +277,7 @@ describe('Content Script - Viewport Translation', () => {
         apiEndpoint: 'https://api.openai.com/v1/chat/completions',
         apiKey: 'test-key',
         model: 'gpt-3.5-turbo',
-        targetLanguage: 'ja',
-        viewportTranslation: true
+        targetLanguage: 'ja'
       })
       
       // Import content script and get the message listener
@@ -334,7 +331,6 @@ describe('Content Script - Viewport Translation', () => {
         apiKey: 'test-key',
         model: 'gpt-3.5-turbo',
         targetLanguage: 'ja',
-        viewportTranslation: false // Explicitly disabled
       })
       
       // Import content script and get the message listener

--- a/test/popup.test.ts
+++ b/test/popup.test.ts
@@ -21,8 +21,7 @@ const mockElements = {
   model: { value: '', addEventListener: vi.fn() } as any,
   targetLanguage: { value: 'Japanese', addEventListener: vi.fn() } as any,
   apiRps: { value: '0.9', addEventListener: vi.fn() } as any,
-  batchSize: { value: '2000', addEventListener: vi.fn() } as any,
-  viewportTranslation: { checked: true, addEventListener: vi.fn() } as any,
+  batchSize: { value: '1000', addEventListener: vi.fn() } as any,
   saveSettings: { addEventListener: vi.fn() } as any,
   translatePage: { addEventListener: vi.fn() } as any,
   restorePage: { addEventListener: vi.fn() } as any,
@@ -38,7 +37,6 @@ document.getElementById = vi.fn((id: string) => {
     'target-language': mockElements.targetLanguage,
     'api-rps': mockElements.apiRps,
     'batch-size': mockElements.batchSize,
-    'viewport-translation': mockElements.viewportTranslation,
     'save-settings': mockElements.saveSettings,
     'translate-page': mockElements.translatePage,
     'restore-page': mockElements.restorePage,
@@ -56,8 +54,7 @@ describe('Popup', () => {
     mockElements.model.value = ''
     mockElements.targetLanguage.value = 'ja'
     mockElements.apiRps.value = '0.9'
-    mockElements.batchSize.value = '2000'
-    mockElements.viewportTranslation.checked = true
+    mockElements.batchSize.value = '1000'
     mockElements.status.textContent = ''
     mockElements.status.className = 'status'
   })
@@ -89,8 +86,7 @@ describe('Popup', () => {
         'model',
         'targetLanguage',
         'apiRps',
-        'batchSize',
-        'viewportTranslation'
+        'batchSize'
       ])
       
       expect(mockElements.apiEndpoint.value).toBe('https://custom.api.com')
@@ -134,8 +130,7 @@ describe('Popup', () => {
         model: 'gpt-4',
         targetLanguage: 'Japanese',
         apiRps: 0.9,
-        batchSize: 2000,
-        viewportTranslation: true
+        batchSize: 1000
       })
       
       expect(mockElements.status.className).toContain('success')
@@ -157,11 +152,10 @@ describe('Popup', () => {
       expect(chrome.storage.local.set).toHaveBeenCalledWith({
         apiEndpoint: 'https://api.openai.com/v1/chat/completions',
         apiKey: 'some-key',
-        model: 'gpt-4.1-mini',
+        model: 'gpt-4.1-nano',
         targetLanguage: 'ja',
         apiRps: 0.9,
-        batchSize: 2000,
-        viewportTranslation: true
+        batchSize: 1000
       })
     })
   })


### PR DESCRIPTION
## Summary
- Change default model to gpt-4.1-nano for better performance
- Reduce default batch size to 1000 characters for smaller API requests
- Simplify UI by removing Smart Translation toggle and making it the only mode

## Changes
- Update default model from `gpt-4.1-mini` to `gpt-4.1-nano`
- Change default batch size from 2000 to 1000 characters
- Remove Smart Translation checkbox from popup UI
- Always use viewport-based translation (Smart Translation) mode
- Update all related tests to reflect these changes

## Test plan
- [x] All existing tests pass
- [x] ESLint checks pass
- [x] TypeScript compilation succeeds
- [x] Extension builds successfully
- [ ] Manual testing: Verify translation works with new defaults
- [ ] Manual testing: Confirm Smart Translation is always active

🤖 Generated with [Claude Code](https://claude.ai/code)