### PR TITLE
fix: Enable retry for failed translations on scroll

### DIFF
--- a/src/batch-translator.ts
+++ b/src/batch-translator.ts
@@ -175,12 +175,19 @@ export class BatchTranslator {
             const restoredHTML = placeholdersToHtml(translation, item.placeholderMap)
             item.element.innerHTML = restoredHTML
             item.element.setAttribute('data-translated', 'true')
+            // Remove failed flag if it was set
+            item.element.removeAttribute('data-translation-failed')
+          } else {
+            // Mark as failed if no translation received
+            item.element.setAttribute('data-translation-failed', 'true')
           }
         }
         
-        // Handle missing translations silently
+        // Mark any remaining items as failed if we got fewer translations
         if (translations.length < batch.length) {
-          // Fewer translations than expected, but continue processing what we have
+          for (let i = translations.length; i < batch.length; i++) {
+            batch[i].element.setAttribute('data-translation-failed', 'true')
+          }
         }
       } else {
         console.error('Batch translation failed:', response.error || 'No translated text')
@@ -212,9 +219,17 @@ export class BatchTranslator {
         const restoredHTML = placeholdersToHtml(response.translatedText, item.placeholderMap)
         item.element.innerHTML = restoredHTML
         item.element.setAttribute('data-translated', 'true')
+        // Remove failed flag if it was set
+        item.element.removeAttribute('data-translation-failed')
+      } else {
+        // Mark as failed for potential retry
+        item.element.setAttribute('data-translation-failed', 'true')
+        console.error('Translation failed for element:', response.error)
       }
     } catch (error) {
       console.error('Translation error:', error)
+      // Mark as failed for potential retry
+      item.element.setAttribute('data-translation-failed', 'true')
     }
   }
 }


### PR DESCRIPTION
## Summary
Fix the issue where DOM elements that failed translation would never be retried, even when scrolling past them again.

## Problem
When translation fails for an element:
1. The element was marked in `translatedElements` WeakSet
2. The IntersectionObserver would skip it on subsequent scrolls
3. Elements without `data-translated` attribute but with failed translation attempts were stuck

## Solution
Implemented a retry mechanism for failed translations:

1. **Mark failed elements**: Add `data-translation-failed` attribute to elements that fail translation
2. **Clean up WeakSet**: Remove failed elements from `translatedElements` to allow retry
3. **Re-observe elements**: After failure, unobserve and re-observe elements to trigger IntersectionObserver
4. **Clear failed flag**: Remove the failed flag when retry is attempted
5. **Comprehensive coverage**: Handle failures in both batch and individual translation paths

## Changes

### `src/content.ts`
- Remove failed elements from `translatedElements` WeakSet
- Add `data-translation-failed` attribute to mark failures
- Re-observe failed elements after 1 second delay
- Clear failed flag when elements are retried

### `src/batch-translator.ts`
- Mark elements with `data-translation-failed` when translation fails
- Handle partial batch failures (fewer translations than elements)
- Clear failed flag on successful translation

## Test plan
- [x] All existing tests pass
- [x] ESLint and TypeScript checks pass
- [x] Build completes successfully
- [ ] Manual testing: Failed translations can be retried on scroll
- [ ] Manual testing: Network errors result in retryable state
- [ ] Manual testing: API errors result in retryable state

## User Experience
Users will now see failed translations automatically retry when they scroll past those elements again, providing a more resilient translation experience.

🤖 Generated with [Claude Code](https://claude.ai/code)