### PR TITLE
fix: Change placeholder mismatch warnings to debug level

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -261,7 +261,7 @@ export function placeholdersToHtml(
           
           // Match same tag type and open/close state
           if (tag.toLowerCase() === pTag.toLowerCase() && isClosing === pIsClosing) {
-            console.warn(`Unmatched placeholder ${match} replaced with ${placeholder}`)
+            console.debug(`Unmatched placeholder ${match} replaced with ${placeholder}`)
             usedPlaceholders.add(placeholder)
             return original
           }
@@ -281,7 +281,7 @@ export function placeholdersToHtml(
           if (pPattern && pPattern[1].toLowerCase() === tag.toLowerCase()) {
             const pIsClosing = placeholder.startsWith('</')
             if (isClosing === pIsClosing) {
-              console.warn(`Unmatched placeholder ${match} replaced with unused ${placeholder}`)
+              console.debug(`Unmatched placeholder ${match} replaced with unused ${placeholder}`)
               usedPlaceholders.add(placeholder)
               return original
             }
@@ -296,7 +296,7 @@ export function placeholdersToHtml(
       const tagName = normalizedMatch.match(/<\/([a-zA-Z]+)_\d+>/)?.[1]
       if (tagName) {
         // Return a reconstructed closing tag
-        console.warn(`Unmatched placeholder ${match} - reconstructing closing tag`)
+        console.debug(`Unmatched placeholder ${match} - reconstructing closing tag`)
         return `</${tagName}>`
       }
     }
@@ -305,13 +305,13 @@ export function placeholdersToHtml(
     if (!normalizedMatch.startsWith('</')) {
       const tagName = normalizedMatch.match(/<([a-zA-Z]+)_\d+>/)?.[1]
       if (tagName) {
-        console.warn(`Unmatched placeholder ${match} - preserving as simple tag`)
+        console.debug(`Unmatched placeholder ${match} - preserving as simple tag`)
         return `<${tagName}>`
       }
     }
     
     // If absolutely no match found and can't reconstruct, log error but don't remove
-    console.error('Critical: Unmatched placeholder could not be resolved:', match)
+    console.debug('Unmatched placeholder could not be resolved:', match)
     return '' // Last resort: remove to avoid broken display
   })
   

--- a/test/utils.placeholder-debug.test.ts
+++ b/test/utils.placeholder-debug.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { placeholdersToHtml } from '../src/utils'
+
+describe('Placeholder Debug Logging', () => {
+  let debugSpy: any
+  
+  beforeEach(() => {
+    // Spy on console.debug instead of console.warn/error
+    debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+  })
+  
+  afterEach(() => {
+    debugSpy.mockRestore()
+  })
+  
+  describe('placeholdersToHtml debug logging', () => {
+    it('should log debug message for unmatched placeholders', () => {
+      const map = new Map([
+        ['<strong_0>', '<strong>'],
+        ['</strong_0>', '</strong>']
+      ])
+      
+      // Text with mismatched placeholder (strong_1 instead of strong_0)
+      const text = 'This is <strong_1>bold</strong_1> text'
+      const result = placeholdersToHtml(text, map)
+      
+      // Should have logged debug messages
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Unmatched placeholder <strong_1>')
+      )
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Unmatched placeholder </strong_1>')
+      )
+      
+      // Result should still have proper HTML structure
+      expect(result).toContain('<strong>')
+      expect(result).toContain('</strong>')
+      expect(result).toContain('bold')
+    })
+    
+    it('should not log warnings when placeholders match correctly', () => {
+      const map = new Map([
+        ['<em_0>', '<em>'],
+        ['</em_0>', '</em>']
+      ])
+      
+      const text = 'This is <em_0>emphasized</em_0> text'
+      const result = placeholdersToHtml(text, map)
+      
+      // Should not have logged any debug messages
+      expect(debugSpy).not.toHaveBeenCalled()
+      
+      // Result should be correct
+      expect(result).toBe('This is <em>emphasized</em> text')
+    })
+    
+    it('should handle tag_N format placeholders that API might return', () => {
+      const map = new Map([
+        ['<span_0>', '<span class="highlight">'],
+        ['</span_0>', '</span>']
+      ])
+      
+      // API might return tag_0, tag_1, etc. instead of span_0
+      const text = 'This is <tag_0>highlighted</tag_0> text'
+      const result = placeholdersToHtml(text, map)
+      
+      // Should log debug about unmatched placeholders
+      expect(debugSpy).toHaveBeenCalled()
+      
+      // Should still produce valid output
+      expect(result).toBeTruthy()
+      expect(result).toContain('highlighted')
+    })
+    
+    it('should log debug for complex nested mismatches', () => {
+      const map = new Map([
+        ['<div_0>', '<div class="container">'],
+        ['</div_0>', '</div>'],
+        ['<span_1>', '<span>'],
+        ['</span_1>', '</span>']
+      ])
+      
+      // Mismatched numbers in translation
+      const text = '<div_2>Content with <span_3>nested</span_3> tags</div_2>'
+      const result = placeholdersToHtml(text, map)
+      
+      // Should have logged multiple debug messages
+      expect(debugSpy.mock.calls.length).toBeGreaterThan(0)
+      
+      // Result should still be somewhat valid
+      expect(result).toContain('Content')
+      expect(result).toContain('nested')
+    })
+    
+    it('should not produce console errors for production use', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      
+      const map = new Map([
+        ['<p_0>', '<p>'],
+        ['</p_0>', '</p>']
+      ])
+      
+      // Completely different placeholder
+      const text = '<tag_99>Paragraph</tag_99>'
+      placeholdersToHtml(text, map)
+      
+      // Should not have logged errors or warnings
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(warnSpy).not.toHaveBeenCalled()
+      
+      // Debug logging should be used instead
+      expect(debugSpy).toHaveBeenCalled()
+      
+      errorSpy.mockRestore()
+      warnSpy.mockRestore()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Changed console.warn and console.error to console.debug for placeholder mismatch messages
- Added comprehensive tests for debug logging behavior
- Users will no longer see these messages cluttering their console

## Problem
The extension was logging frequent warning messages like:
```
Unmatched placeholder <tag_0> - preserving as simple tag
Unmatched placeholder </tag_0> - reconstructing closing tag
```

These messages appeared regularly during normal operation because LLMs sometimes modify placeholder formats during translation (e.g., changing `<span_0>` to `<tag_0>` or `<span_1>`).

## Solution
- Changed all placeholder mismatch logging from `console.warn`/`console.error` to `console.debug`
- The fallback logic handles these cases gracefully, so they don't need to be user-visible warnings
- Debug messages are still available for developers who need to troubleshoot issues

## Changes Made
1. **src/utils.ts**
   - Changed 4 `console.warn` calls to `console.debug`
   - Changed 1 `console.error` call to `console.debug`

2. **test/utils.placeholder-debug.test.ts** (new file)
   - Added tests to verify debug logging works correctly
   - Ensures no console.warn or console.error messages are produced
   - Tests various placeholder mismatch scenarios

## Test Plan
- [x] All existing tests pass
- [x] New tests verify debug logging behavior
- [x] No warnings or errors appear in normal console output
- [x] Debug messages are still available when needed

🤖 Generated with [Claude Code](https://claude.ai/code)